### PR TITLE
Add missing item damage to minions

### DIFF
--- a/GGOrbwalker.lua
+++ b/GGOrbwalker.lua
@@ -1524,6 +1524,12 @@ Damage = {
 					args.DamageType == DAMAGE_TYPE_MAGICAL
 				)
 		end
+		-- Focus passive from Doran items and Tear of the Goddess
+		if args.TargetIsMinion and args.Target.maxHealth > 6 then
+			if Item:HasItem(from, 1054) or Item:HasItem(from, 1056) or Item:HasItem(from, 3070) then
+				args.CalculatedPhysical = args.CalculatedPhysical + 5
+			end
+		end
 		local percentMod = 1
 		if args.From.critChance - 1 == 0 or args.CriticalStrike then
 			percentMod = percentMod * self:GetCriticalStrikePercent(args.From)


### PR DESCRIPTION
Currently the orbwalker does not include the extra damage to minions from items like Doran Shield, Doran Ring and Tear of the Goddess. This commit adds that.